### PR TITLE
Fixed timezone bug which caused problems to be incorrectly marked late.

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import scraper
 import problems
 import sys
+from datetime import timedelta
 
 # Read command line arguments
 if len(sys.argv) not in {4,5}:
@@ -85,7 +86,8 @@ for a in assignments:
 
     for prob in problist:
         if prob in userdata:
-            score = submission_score(deadline, userdata[prob])
+            local_time = userdata[prob] - timedelta(hours=8, minutes=0)
+            score = submission_score(deadline, local_time)
         else:
             score = 0
 

--- a/main.py
+++ b/main.py
@@ -87,6 +87,7 @@ for a in assignments:
     for prob in problist:
         if prob in userdata:
             local_time = userdata[prob] - timedelta(hours=8, minutes=0)
+            # print(local_time) # Uncomment To Debug
             score = submission_score(deadline, local_time)
         else:
             score = 0


### PR DESCRIPTION
Timezone caused problems to be incorrectly marked as late. Issue was resolved by subtracting 8 hours from the submission time. I confirmed that submission times were correct following this change via comparing the output of print statements with the submission times registered on kattis.